### PR TITLE
Add installation instructions & fix install bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ python setup.py install
 
 Next run the Casper simulator!
 ```
-$ source ./tmux.sh
+$ ./tmux.sh
 ```
 
 You're done!

--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
 # Simple Casper
 
 Layer-2 Casper daemon for POC4.
+
+## Setup
+### Requirements
+- `Python2.7`
+- `automake`
+- `libffi`
+- `tmux`
+
+### Getting started
+Make sure you have installed the requirements, and have created a virtual enviornment.
+Now install the project dependencies:
+```
+$ pip install -r requirements.txt
+$ python setup.py install
+```
+
+Next run the Casper simulator!
+```
+$ source ./tmux.sh
+```
+
+You're done!

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ gevent==1.1.0
 leveldb
 click
 wheel
-rlp>=0.4.4
+rlp==0.4.6
 devp2p>=0.8.0
 ethereum>=1.6.0
 web3>=3.7.2


### PR DESCRIPTION
It took me a while to sort out dependencies required to get the simulator running, so I figured I'd record some basic instructions for the next person who wants to get it running. 

I'm probably missing packages in the `Requirements` section of the README, but I added the requirements I am aware of. 

Also, I was getting an error: `error: rlp 0.4.7 is installed but rlp<=0.4.6,>=0.4.4 is required by set(['devp2p'])` so I changed the required `rlp` version to `0.4.6` in `requirements.txt`