### PR TITLE
fix broken dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ click
 wheel
 rlp>=0.4.4
 devp2p>=0.8.0
-ethereum>=1.6.0
-web3>=3.7.2
+git+https://github.com/ethereum/pyethereum.git@state_revamp
+web3>=3.8.0

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ INSTALL_REQUIRES_REPLACEMENTS = {}
 INSTALL_REQUIRES = list()
 with open('requirements.txt') as requirements_file:
     for requirement in requirements_file:
+        # install_requires will break on git URLs, so skip them
+        if 'git+' in requirement:
+            continue
         dependency = INSTALL_REQUIRES_REPLACEMENTS.get(
             requirement.strip(),
             requirement.strip(),


### PR DESCRIPTION
This PR fixes two issues I was having with the dependencies. Here's what was going on:
1) devp2p & web3 had conflicting `rlp` versions, so I opened an [issue on `web3.py`](https://github.com/pipermerriam/web3.py/issues/170) and the `rlp` version was shortly thereafter kindly updated to 0.4.7
2) The version of pyethereum that is being used seems to be the
`state_revamp` branch, so I reflected that in the requirements.