### PR TITLE
add account management

### DIFF
--- a/simplecasper/accounts.py
+++ b/simplecasper/accounts.py
@@ -1,0 +1,492 @@
+# Copied from https://github.com/ethereum/pyethapp/blob/e7717367387e506d8bed096bba1e553d11f0ac8b/pyethapp/accounts.py
+
+import json
+import os
+import random
+import shutil
+from uuid import UUID
+from devp2p.service import BaseService
+from ethereum import keys
+from ethereum.slogging import get_logger
+from ethereum.utils import privtopub  # this is different  than the one used in devp2p.crypto
+from ethereum.utils import sha3, is_string, decode_hex, remove_0x_head
+log = get_logger('accounts')
+
+DEFAULT_COINBASE = 'de0b295669a9fd93d5f28d9ec85e40f4cb697bae'.decode('hex')
+
+
+def mk_privkey(seed):
+    return sha3(seed)
+
+
+def mk_random_privkey():
+    k = hex(random.getrandbits(256))[2:-1].zfill(64)
+    assert len(k) == 64
+    return k.decode('hex')
+
+
+class Account(object):
+
+    """Represents an account.
+    :ivar keystore: the key store as a dictionary (as decoded from json)
+    :ivar locked: `True` if the account is locked and neither private nor public keys can be
+                  accessed, otherwise `False`
+    :ivar path: absolute path to the associated keystore file (`None` for in-memory accounts)
+    """
+
+    def __init__(self, keystore, password=None, path=None):
+        self.keystore = keystore
+        try:
+            self._address = self.keystore['address'].decode('hex')
+        except KeyError:
+            self._address = None
+        self.locked = True
+        if password is not None:
+            self.unlock(password)
+        if path is not None:
+            self.path = os.path.abspath(path)
+        else:
+            self.path = None
+
+    @classmethod
+    def new(cls, password, key=None, uuid=None, path=None):
+        """Create a new account.
+        Note that this creates the account in memory and does not store it on disk.
+        :param password: the password used to encrypt the private key
+        :param key: the private key, or `None` to generate a random one
+        :param uuid: an optional id
+        """
+        if key is None:
+            key = mk_random_privkey()
+        keystore = keys.make_keystore_json(key, password)
+        keystore['id'] = uuid
+        return Account(keystore, password, path)
+
+    @classmethod
+    def load(cls, path, password=None):
+        """Load an account from a keystore file.
+        :param path: full path to the keyfile
+        :param password: the password to decrypt the key file or `None` to leave it encrypted
+        """
+        with open(path) as f:
+            keystore = json.load(f)
+        if not keys.check_keystore_json(keystore):
+            raise ValueError('Invalid keystore file')
+        return Account(keystore, password, path=path)
+
+    def dump(self, include_address=True, include_id=True):
+        """Dump the keystore for later disk storage.
+        The result inherits the entries `'crypto'` and `'version`' from `account.keystore`, and
+        adds `'address'` and `'id'` in accordance with the parameters `'include_address'` and
+        `'include_id`'.
+        If address or id are not known, they are not added, even if requested.
+        :param include_address: flag denoting if the address should be included or not
+        :param include_id: flag denoting if the id should be included or not
+        """
+        d = {}
+        d['crypto'] = self.keystore['crypto']
+        d['version'] = self.keystore['version']
+        if include_address and self.address is not None:
+            d['address'] = self.address.encode('hex')
+        if include_id and self.uuid is not None:
+            d['id'] = self.uuid
+        return json.dumps(d)
+
+    def unlock(self, password):
+        """Unlock the account with a password.
+        If the account is already unlocked, nothing happens, even if the password is wrong.
+        :raises: :exc:`ValueError` (originating in ethereum.keys) if the password is wrong (and the
+                 account is locked)
+        """
+        if self.locked:
+            self._privkey = keys.decode_keystore_json(self.keystore, password)
+            self.locked = False
+            self.address  # get address such that it stays accessible after a subsequent lock
+
+    def lock(self):
+        """Relock an unlocked account.
+        This method sets `account.privkey` to `None` (unlike `account.address` which is preserved).
+        After calling this method, both `account.privkey` and `account.pubkey` are `None.
+        `account.address` stays unchanged, even if it has been derived from the private key.
+        """
+        self._privkey = None
+        self.locked = True
+
+    @property
+    def privkey(self):
+        """The account's private key or `None` if the account is locked"""
+        if not self.locked:
+            return self._privkey
+        else:
+            return None
+
+    @property
+    def pubkey(self):
+        """The account's public key or `None` if the account is locked"""
+        if not self.locked:
+            return privtopub(self.privkey)
+        else:
+            return None
+
+    @property
+    def address(self):
+        """The account's address or `None` if the address is not stored in the key file and cannot
+        be reconstructed (because the account is locked)
+        """
+        if self._address:
+            pass
+        elif 'address' in self.keystore:
+            self._address = self.keystore['address'].decode('hex')
+        elif not self.locked:
+            self._address = keys.privtoaddr(self.privkey)
+        else:
+            return None
+        return self._address
+
+    @property
+    def uuid(self):
+        """An optional unique identifier, formatted according to UUID version 4, or `None` if the
+        account does not have an id
+        """
+        try:
+            return self.keystore['id']
+        except KeyError:
+            return None
+
+    @uuid.setter
+    def uuid(self, value):
+        """Set the UUID. Set it to `None` in order to remove it."""
+        if value is not None:
+            self.keystore['id'] = value
+        elif 'id' in self.keystore:
+            self.keystore.pop('id')
+
+    def sign_tx(self, tx):
+        """Sign a Transaction with the private key of this account.
+        If the account is unlocked, this is equivalent to ``tx.sign(account.privkey)``.
+        :param tx: the :class:`ethereum.transactions.Transaction` to sign
+        :raises: :exc:`ValueError` if the account is locked
+        """
+        if self.privkey:
+            log.info('signing tx', tx=tx, account=self)
+            tx.sign(self.privkey)
+        else:
+            raise ValueError('Locked account cannot sign tx')
+
+    def __repr__(self):
+        if self.address is not None:
+            address = self.address.encode('hex')
+        else:
+            address = '?'
+        return '<Account(address={address}, id={id})>'.format(address=address, id=self.uuid)
+
+
+class AccountsService(BaseService):
+
+    """Service that manages accounts.
+    At initialization, this service collects the accounts stored as key files in the keystore
+    directory (config option `accounts.keystore_dir`) and below.
+    To add more accounts, use :method:`add_account`.
+    :ivar accounts: the :class:`Account`s managed by this service, sorted by the paths to their
+                    keystore files
+    :ivar keystore_dir: absolute path to the keystore directory
+    """
+
+    name = 'accounts'
+    default_config = dict(accounts=dict(keystore_dir='keystore', must_include_coinbase=True))
+
+    def __init__(self, app):
+        super(AccountsService, self).__init__(app)
+        self.keystore_dir = app.config['accounts']['keystore_dir']
+        if not os.path.isabs(self.keystore_dir):
+            self.keystore_dir = os.path.abspath(os.path.join(app.config['node']['data_dir'],
+                                                             self.keystore_dir))
+        assert os.path.isabs(self.keystore_dir)
+        self.accounts = []
+        if not os.path.exists(self.keystore_dir):
+            log.warning('keystore directory does not exist', directory=self.keystore_dir)
+        elif not os.path.isdir(self.keystore_dir):
+            log.error('configured keystore directory is a file, not a directory',
+                      directory=self.keystore_dir)
+        else:
+            # traverse file tree rooted at keystore_dir
+            log.info('searching for key files', directory=self.keystore_dir)
+            for dirpath, _, filenames in os.walk(self.keystore_dir):
+                for filename in [os.path.join(dirpath, filename) for filename in filenames]:
+                    try:
+                        self.accounts.append(Account.load(filename))
+                    except ValueError:
+                        log.warning('invalid file skipped in keystore directory',
+                                    path=filename)
+        self.accounts.sort(key=lambda account: account.path)  # sort accounts by path
+        if not self.accounts:
+            log.warn('no accounts found')
+        else:
+            log.info('found account(s)', accounts=self.accounts)
+
+    @property
+    def coinbase(self):
+        """Return the address that should be used as coinbase for new blocks.
+        The coinbase address is given by the config field pow.coinbase_hex. If this does not exist
+        or is `None`, the address of the first account is used instead. If there are no accounts,
+        the coinbase is `DEFAULT_COINBASE`.
+        :raises: :exc:`ValueError` if the coinbase is invalid (no string, wrong length) or there is
+                 no account for it and the config flag `accounts.check_coinbase` is set (does not
+                 apply to the default coinbase)
+        """
+        cb_hex = self.app.config.get('pow', {}).get('coinbase_hex')
+        if cb_hex is None:
+            if not self.accounts_with_address:
+                return DEFAULT_COINBASE
+            cb = self.accounts_with_address[0].address
+        else:
+            if not is_string(cb_hex):
+                raise ValueError('coinbase must be string')
+            try:
+                cb = decode_hex(remove_0x_head(cb_hex))
+            except (ValueError, TypeError):
+                raise ValueError('invalid coinbase')
+        if len(cb) != 20:
+            raise ValueError('wrong coinbase length')
+        if self.config['accounts']['must_include_coinbase']:
+            if cb not in (acct.address for acct in self.accounts):
+                raise ValueError('no account for coinbase')
+        return cb
+
+    def add_account(self, account, store=True, include_address=True, include_id=True):
+        """Add an account.
+        If `store` is true the account will be stored as a key file at the location given by
+        `account.path`. If this is `None` a :exc:`ValueError` is raised. `include_address` and
+        `include_id` determine if address and id should be removed for storage or not.
+        This method will raise a :exc:`ValueError` if the new account has the same UUID as an
+        account already known to the service. Note that address collisions do not result in an
+        exception as those may slip through anyway for locked accounts with hidden addresses.
+        """
+        log.info('adding account', account=account)
+        if account.uuid is not None:
+            if len([acct for acct in self.accounts if acct.uuid == account.uuid]) > 0:
+                log.error('could not add account (UUID collision)', uuid=account.uuid)
+                raise ValueError('Could not add account (UUID collision)')
+        if store:
+            if account.path is None:
+                raise ValueError('Cannot store account without path')
+            assert os.path.isabs(account.path), account.path
+            if os.path.exists(account.path):
+                log.error('File does already exist', path=account.path)
+                raise IOError('File does already exist')
+            assert account.path not in [acct.path for acct in self.accounts]
+            try:
+                directory = os.path.dirname(account.path)
+                if not os.path.exists(directory):
+                    os.makedirs(directory)
+                with open(account.path, 'w') as f:
+                    f.write(account.dump(include_address, include_id))
+            except IOError as e:
+                log.error('Could not write to file', path=account.path, message=e.strerror,
+                          errno=e.errno)
+                raise
+        self.accounts.append(account)
+        self.accounts.sort(key=lambda account: account.path)
+
+    def update_account(self, account, new_password, include_address=True, include_id=True):
+        """Replace the password of an account.
+        The update is carried out in three steps:
+        1) the old keystore file is renamed
+        2) the new keystore file is created at the previous location of the old keystore file
+        3) the old keystore file is removed
+        In this way, at least one of the keystore files exists on disk at any time and can be
+        recovered if the process is interrupted.
+        :param account: the :class:`Account` which must be unlocked, stored on disk and included in
+                        :attr:`AccountsService.accounts`.
+        :param include_address: forwarded to :meth:`add_account` during step 2
+        :param include_id: forwarded to :meth:`add_account` during step 2
+        :raises: :exc:`ValueError` if the account is locked, if it is not added to the account
+                 manager, or if it is not stored
+        """
+        if account not in self.accounts:
+            raise ValueError('Account not managed by account service')
+        if account.locked:
+            raise ValueError('Cannot update locked account')
+        if account.path is None:
+            raise ValueError('Account not stored on disk')
+        assert os.path.isabs(account.path)
+
+        # create new account
+        log.debug('creating new account')
+        new_account = Account.new(new_password, key=account.privkey, uuid=account.uuid)
+        new_account.path = account.path
+
+        # generate unique path and move old keystore file there
+        backup_path = account.path + '~'
+        i = 1
+        while os.path.exists(backup_path):
+            backup_path = backup_path[:backup_path.rfind('~') + 1] + str(i)
+            i += 1
+        assert not os.path.exists(backup_path)
+        log.info('moving old keystore file to backup location', **{'from': account.path,
+                                                                   'to': backup_path})
+        try:
+            shutil.move(account.path, backup_path)
+        except:
+            log.error('could not backup keystore, stopping account update',
+                      **{'from': account.path, 'to': backup_path})
+            raise
+
+        assert os.path.exists(backup_path)
+        assert not os.path.exists(new_account.path)
+        account.path = backup_path
+
+        # remove old account from manager (not from disk yet) and add new account
+        self.accounts.remove(account)
+        assert account not in self.accounts
+        try:
+            self.add_account(new_account, include_address, include_id)
+        except:
+            log.error('adding new account failed, recovering from backup')
+            shutil.move(backup_path, new_account.path)
+            self.accounts.append(account)
+            self.accounts.sort(key=lambda account: account.path)
+            raise
+
+        assert os.path.exists(new_account.path)
+        assert new_account in self.accounts
+
+        # everything was successful (we are still here), so delete old keystore file
+        log.info('deleting backup of old keystore', path=backup_path)
+        try:
+            os.remove(backup_path)
+        except:
+            log.error('failed to delete no longer needed backup of old keystore',
+                      path=account.path)
+            raise
+
+        # set members of account to values of new_account
+        account.keystore = new_account.keystore
+        account.path = new_account.path
+        assert account.__dict__ == new_account.__dict__
+        # replace new_account by old account in account list
+        self.accounts.append(account)
+        self.accounts.remove(new_account)
+        self.accounts.sort(key=lambda account: account.path)
+        log.debug('account update successful')
+
+    @property
+    def accounts_with_address(self):
+        """Return a list of accounts whose address is known."""
+        return [account for account in self if account.address]
+
+    @property
+    def unlocked_accounts(self):
+        """Return a list of all unlocked accounts."""
+        return [account for account in self if not account.locked]
+
+    def find(self, identifier):
+        """Find an account by either its address, its id or its index as string.
+        Example identifiers:
+        - '9c0e0240776cfbe6fa1eb37e57721e1a88a563d1' (address)
+        - '0x9c0e0240776cfbe6fa1eb37e57721e1a88a563d1' (address with 0x prefix)
+        - '01dd527b-f4a5-4b3c-9abb-6a8e7cd6722f' (UUID)
+        - '3' (index)
+        :param identifier: the accounts hex encoded, case insensitive address (with optional 0x
+                           prefix), its UUID or its index (as string, >= 1) in
+                           `account_service.accounts`
+        :raises: :exc:`ValueError` if the identifier could not be interpreted
+        :raises: :exc:`KeyError` if the identified account is not known to the account_service
+        """
+        try:
+            uuid = UUID(identifier)
+        except ValueError:
+            pass
+        else:
+            return self.get_by_id(str(uuid))
+
+        try:
+            index = int(identifier, 10)
+        except ValueError:
+            pass
+        else:
+            if index <= 0:
+                raise ValueError('Index must be 1 or greater')
+            try:
+                return self.accounts[index - 1]
+            except IndexError as e:
+                raise KeyError(e.message)
+
+        if identifier[:2] == '0x':
+            identifier = identifier[2:]
+        try:
+            address = identifier.decode('hex')
+        except TypeError:
+            success = False
+        else:
+            if len(address) != 20:
+                success = False
+            else:
+                return self[address]
+
+        assert not success
+        raise ValueError('Could not interpret account identifier')
+
+    def get_by_id(self, id):
+        """Return the account with a given id.
+        Note that accounts are not required to have an id.
+        :raises: `KeyError` if no matching account can be found
+        """
+        accts = [acct for acct in self.accounts if UUID(acct.uuid) == UUID(id)]
+        assert len(accts) <= 1
+        if len(accts) == 0:
+            raise KeyError('account with id {} unknown'.format(id))
+        elif len(accts) > 1:
+            log.warning('multiple accounts with same UUID found', uuid=id)
+        return accts[0]
+
+    def get_by_address(self, address):
+        """Get an account by its address.
+        Note that even if an account with the given address exists, it might not be found if it is
+        locked. Also, multiple accounts with the same address may exist, in which case the first
+        one is returned (and a warning is logged).
+        :raises: `KeyError` if no matching account can be found
+        """
+        assert len(address) == 20
+        accounts = [account for account in self.accounts if account.address == address]
+        if len(accounts) == 0:
+            raise KeyError('account not found by address', address=address.encode('hex'))
+        elif len(accounts) > 1:
+            log.warning('multiple accounts with same address found', address=address.encode('hex'))
+        return accounts[0]
+
+    def sign_tx(self, address, tx):
+        self.get_by_address(address).sign_tx(tx)
+
+    def propose_path(self, address):
+        return os.path.join(self.keystore_dir, address.encode('hex'))
+
+    def __contains__(self, address):
+        assert len(address) == 20
+        return address in [a.address for a in self.accounts]
+
+    def __getitem__(self, address_or_idx):
+        if isinstance(address_or_idx, bytes):
+            address = address_or_idx
+            assert len(address) == 20
+            for a in self.accounts:
+                if a.address == address:
+                    return a
+            raise KeyError
+        else:
+            assert isinstance(address_or_idx, int)
+            return self.accounts[address_or_idx]
+
+    def __iter__(self):
+        return iter(self.accounts)
+
+    def __len__(self):
+        return len(self.accounts)
+
+
+"""
+--import-key = key.json
+--unlock <password dialog>
+--password  passwordfile
+--newkey    <password dialog>
+"""

--- a/simplecasper/app.py
+++ b/simplecasper/app.py
@@ -3,6 +3,7 @@ import os
 import signal
 import sys
 from logging import StreamHandler
+from uuid import uuid4
 
 import click
 import gevent
@@ -11,6 +12,7 @@ from gevent.event import Event
 import ethereum.slogging as slogging
 from casper_service import CasperService
 from chain_service import ChainService
+from accounts import AccountsService, Account
 from db_service import DBService
 from devp2p.app import BaseApp
 from devp2p.discovery import NodeDiscovery
@@ -22,7 +24,7 @@ from simplecasper import __version__
 slogging.PRINT_FORMAT = '%(asctime)s %(name)s:%(levelname).1s\t%(message)s'
 log = slogging.get_logger('app')
 
-services = [NodeDiscovery, PeerManager, DBService, ChainService, CasperService]
+services = [NodeDiscovery, PeerManager, DBService, AccountsService, ChainService, CasperService]
 
 privkeys = [encode_hex(sha3(i)) for i in range(100, 200)]
 pubkeys = [encode_hex(privtopub(decode_hex(k))[1:]) for k in privkeys]
@@ -45,8 +47,11 @@ class SimpleCasper(BaseApp):
               help='log_config string: e.g. ":info,eth:debug', show_default=True)
 @click.option('--log-file', type=click.Path(dir_okay=False, writable=True, resolve_path=True),
               help="Log to file instead of stderr.")
+@click.option('--unlock', multiple=True, type=str,
+              help='Unlock an account (prompts for password)')
+@click.option('--password', type=click.File(), help='path to a password file')
 @click.pass_context
-def app(ctx, log_config, log_file):
+def app(ctx, log_config, log_file, unlock, password):
     slogging.configure(log_config, log_file=log_file)
     ctx.obj = {
         'log_config': log_config,
@@ -73,13 +78,15 @@ def app(ctx, log_config, log_file):
                 'max_peers': 4,
                 'min_peers': 4
             }
-        }
+        },
+        'unlock': unlock,
+        'password': password.read().rstrip() if password else None
     }
 
 
 @app.command()
-@click.argument('node_id', type=click.IntRange(0,100))
-@click.option('--console',  is_flag=True, help='Immediately drop into interactive console.')
+@click.argument('node_id', type=click.IntRange(0, 100))
+@click.option('--console', is_flag=True, help='Immediately drop into interactive console.')
 @click.pass_context
 def run(ctx, node_id, console):
     """Start the daemon"""
@@ -125,6 +132,231 @@ def run(ctx, node_id, console):
     # finally stop
     app.stop()
 
+
+@app.group()
+@click.pass_context
+def account(ctx):
+    """Manage accounts.
+    For accounts to be accessible by pyethapp, their keys must be stored in the keystore directory.
+    Its path can be configured through "accounts.keystore_dir".
+    """
+    app = SimpleCasper(ctx.obj['config'])
+    ctx.obj['app'] = app
+    AccountsService.register_with_app(app)
+    unlock_accounts(ctx.obj['unlock'], app.services.accounts, password=ctx.obj['password'])
+
+
+@account.command('new')
+@click.option('--uuid', '-i', help='equip the account with a random UUID', is_flag=True)
+@click.pass_context
+def new_account(ctx, uuid):
+    """Create a new account.
+
+    This will generate a random private key and store it in encrypted form in the keystore
+    directory. You are prompted for the password that is employed (if no password file is
+    specified). If desired the private key can be associated with a random UUID (version 4) using
+    the --uuid flag.
+    """
+    app = ctx.obj['app']
+    if uuid:
+        id_ = str(uuid4())
+    else:
+        id_ = None
+    password = ctx.obj['password']
+    if password is None:
+        password = click.prompt('Password to encrypt private key', default='', hide_input=True,
+                                confirmation_prompt=True, show_default=False)
+    account = Account.new(password, uuid=id_)
+    account.path = os.path.join(app.services.accounts.keystore_dir, account.address.encode('hex'))
+    try:
+        app.services.accounts.add_account(account)
+    except IOError:
+        click.echo('Could not write keystore file. Make sure you have write permission in the '
+                   'configured directory and check the log for further information.')
+        sys.exit(1)
+    else:
+        click.echo('Account creation successful')
+        click.echo('  Address: ' + account.address.encode('hex'))
+        click.echo('       Id: ' + str(account.uuid))
+
+
+@account.command('list')
+@click.pass_context
+def list_accounts(ctx):
+    """List accounts with addresses and ids.
+
+    This prints a table of all accounts, numbered consecutively, along with their addresses and
+    ids. Note that some accounts do not have an id, and some addresses might be hidden (i.e. are
+    not present in the keystore file). In the latter case, you have to unlock the accounts (e.g.
+    via "pyethapp --unlock <account> account list") to display the address anyway.
+    """
+    accounts = ctx.obj['app'].services.accounts
+    if len(accounts) == 0:
+        click.echo('no accounts found')
+    else:
+        fmt = '{i:>4} {address:<40} {id:<36} {locked:<1}'
+        click.echo('     {address:<40} {id:<36} {locked}'.format(address='Address (if known)',
+                                                                 id='Id (if any)',
+                                                                 locked='Locked'))
+        for i, account in enumerate(accounts):
+            click.echo(fmt.format(i='#' + str(i + 1),
+                                  address=(account.address or '').encode('hex'),
+                                  id=account.uuid or '',
+                                  locked='yes' if account.locked else 'no'))
+
+
+@account.command('import')
+@click.argument('f', type=click.File(), metavar='FILE')
+@click.option('--uuid', '-i', help='equip the new account with a random UUID', is_flag=True)
+@click.pass_context
+def import_account(ctx, f, uuid):
+    """Import a private key from FILE.
+
+    FILE is the path to the file in which the private key is stored. The key is assumed to be hex
+    encoded, surrounding whitespace is stripped. A new account is created for the private key, as
+    if it was created with "pyethapp account new", and stored in the keystore directory. You will
+    be prompted for a password to encrypt the key (if no password file is specified). If desired a
+    random UUID (version 4) can be generated using the --uuid flag in order to identify the new
+    account later.
+    """
+    app = ctx.obj['app']
+    if uuid:
+        id_ = str(uuid4())
+    else:
+        id_ = None
+    privkey_hex = f.read()
+    try:
+        privkey = privkey_hex.strip().decode('hex')
+    except TypeError:
+        click.echo('Could not decode private key from file (should be hex encoded)')
+        sys.exit(1)
+    password = ctx.obj['password']
+    if password is None:
+        password = click.prompt('Password to encrypt private key', default='', hide_input=True,
+                                confirmation_prompt=True, show_default=False)
+    account = Account.new(password, privkey, uuid=id_)
+    account.path = os.path.join(app.services.accounts.keystore_dir, account.address.encode('hex'))
+    try:
+        app.services.accounts.add_account(account)
+    except IOError:
+        click.echo('Could not write keystore file. Make sure you have write permission in the '
+                   'configured directory and check the log for further information.')
+        sys.exit(1)
+    else:
+        click.echo('Account creation successful')
+        click.echo('  Address: ' + account.address.encode('hex'))
+        click.echo('       Id: ' + str(account.uuid))
+
+
+@account.command('update')
+@click.argument('account', type=str)
+@click.pass_context
+def update_account(ctx, account):
+    """
+    Change the password of an account.
+
+    ACCOUNT identifies the account: It can be one of the following: an address, a uuid, or a
+    number corresponding to an entry in "pyethapp account list" (one based).
+
+    "update" first prompts for the current password to unlock the account. Next, the new password
+    must be entered.
+
+    The password replacement procedure backups the original keystore file in the keystore
+    directory, creates the new file, and finally deletes the backup. If something goes wrong, an
+    attempt will be made to restore the keystore file from the backup. In the event that this does
+    not work, it is possible to recover from the backup manually by simply renaming it. The backup
+    shares the same name as the original file, but with an appended "~" plus a number if necessary
+    to avoid name clashes.
+
+    As this command tampers with your keystore directory, it is advisable to perform a manual
+    backup in advance.
+
+    If a password is provided via the "--password" option (on the "pyethapp" base command), it will
+    be used to unlock the account, but not as the new password (as distinguished from
+    "pyethapp account new").
+    """
+    app = ctx.obj['app']
+    unlock_accounts([account], app.services.accounts, password=ctx.obj['password'])
+    old_account = app.services.accounts.find(account)
+    if old_account.locked:
+        click.echo('Account needs to be unlocked in order to update its password')
+        sys.exit(1)
+
+    click.echo('Updating account')
+    click.echo('Address: {}'.format(old_account.address.encode('hex')))
+    click.echo('     Id: {}'.format(old_account.uuid))
+
+    new_password = click.prompt('New password', default='', hide_input=True,
+                                confirmation_prompt=True, show_default=False)
+
+    try:
+        app.services.accounts.update_account(old_account, new_password)
+    except:
+        click.echo('Account update failed. Make sure that the keystore file has been restored '
+                   'correctly (e.g. with "pyethapp --unlock <acct> account list"). If not, look '
+                   'for automatic backup files in the keystore directory (suffix "~" or '
+                   '"~<number>"). Check the log for further information.')
+        raise
+    click.echo('Account update successful')
+
+
+def unlock_accounts(account_ids, account_service, max_attempts=3, password=None):
+    """Unlock a list of accounts, prompting for passwords one by one if not given.
+
+    If a password is specified, it will be used to unlock all accounts. If not, the user is
+    prompted for one password per account.
+
+    If an account can not be identified or unlocked, an error message is logged and the program
+    exits.
+
+    :param accounts: a list of account identifiers accepted by :meth:`AccountsService.find`
+    :param account_service: the account service managing the given accounts
+    :param max_attempts: maximum number of attempts per account before the unlocking process is
+                         aborted (>= 1), or `None` to allow an arbitrary number of tries
+    :param password: optional password which will be used to unlock the accounts
+    """
+    accounts = []
+    for account_id in account_ids:
+        try:
+            account = account_service.find(account_id)
+        except KeyError:
+            log.fatal('could not find account', identifier=account_id)
+            sys.exit(1)
+        accounts.append(account)
+
+    if password is not None:
+        for identifier, account in zip(account_ids, accounts):
+            try:
+                account.unlock(password)
+            except ValueError:
+                log.fatal('Could not unlock account with password from file',
+                          account_id=identifier)
+                sys.exit(1)
+        return
+
+    max_attempts_str = str(max_attempts) if max_attempts else 'oo'
+    attempt_fmt = '(attempt {{attempt}}/{})'.format(max_attempts_str)
+    first_attempt_fmt = 'Password for account {id} ' + attempt_fmt
+    further_attempts_fmt = 'Wrong password. Please try again ' + attempt_fmt
+
+    for identifier, account in zip(account_ids, accounts):
+        attempt = 1
+        pw = click.prompt(first_attempt_fmt.format(id=identifier, attempt=1), hide_input=True,
+                          default='', show_default=False)
+        while True:
+            attempt += 1
+            try:
+                account.unlock(pw)
+            except ValueError:
+                if max_attempts and attempt > max_attempts:
+                    log.fatal('Too many unlock attempts', attempts=attempt, account_id=identifier)
+                    sys.exit(1)
+                else:
+                    pw = click.prompt(further_attempts_fmt.format(attempt=attempt),
+                                      hide_input=True, default='', show_default=False)
+            else:
+                break
+        assert not account.locked
 
 if __name__ == '__main__':
     app()

--- a/simplecasper/casper_service.py
+++ b/simplecasper/casper_service.py
@@ -28,7 +28,8 @@ class CasperService(WiredService):
         self.bcast = app.services.peermanager.broadcast
 
         cfg = app.config['casper']
-        self.privkey = cfg['privkey']
+        self.account = app.services.accounts.get_by_address(app.services.accounts.coinbase)
+        self.privkey = self.account.privkey
         if 'network_id' in self.db:
             db_network_id = self.db.get('network_id')
             if db_network_id != str(cfg['network_id']):

--- a/tmux.sh
+++ b/tmux.sh
@@ -5,22 +5,22 @@ tmux start-server;
 TMUX= tmux new-session -d -s simplecasper -n casper-daemons
 
 tmux send-keys -t simplecasper:0.0 source\ \~/.zshrc C-m
-tmux send-keys -t simplecasper:0.0 simplecasper\ -l\ casper:debug\ run\ 0 C-m
+tmux send-keys -t simplecasper:0.0 simplecasper\ -l\ casper:debug\ -d\ data0\ run\ 0\ --fake-account C-m
 
 tmux splitw -t simplecasper:0
 tmux select-layout -t simplecasper:0 tiled
 tmux send-keys -t simplecasper:0.1 source\ \~/.zshrc C-m
-tmux send-keys -t simplecasper:0.1 simplecasper\ -l\ casper:debug\ run\ 1 C-m
+tmux send-keys -t simplecasper:0.1 simplecasper\ -l\ casper:debug\ -d\ data1\ run\ 1\ --fake-account C-m
 
 tmux splitw -t simplecasper:0
 tmux select-layout -t simplecasper:0 tiled
 tmux send-keys -t simplecasper:0.2 source\ \~/.zshrc C-m
-tmux send-keys -t simplecasper:0.2 simplecasper\ -l\ casper:debug\ run\ 2 C-m
+tmux send-keys -t simplecasper:0.2 simplecasper\ -l\ casper:debug\ -d\ data2\ run\ 2\ --fake-account C-m
 
 tmux splitw -t simplecasper:0
 tmux select-layout -t simplecasper:0 tiled
 tmux send-keys -t simplecasper:0.3 source\ \~/.zshrc C-m
-tmux send-keys -t simplecasper:0.3 simplecasper\ -l\ casper:debug\ run\ 3 C-m
+tmux send-keys -t simplecasper:0.3 simplecasper\ -l\ casper:debug\ -d\ data3\ run\ 3\ --fake-account C-m
 
 tmux select-layout -t simplecasper:0 tiled
 tmux select-pane -t simplecasper:0.0


### PR DESCRIPTION
*This is a work in progress and opened in order to receive feedback*

This PR adds account management. It lets you use `simplecasper account [new,list,import,update]`. It also sets the private key that is used in the `casper_service` to be the unlocked account instead of the dummy private keys.

## Features
- encrypted private keys with unlock options
- `account` command for account management
- `--fake-account` flag used for testing without ever creating a private key. This uses a private key based on `node_id` as was implemented previously
- `--data-dir` lets you specify a data directory directly instead of it being based off of the `node_id`
- updated `tmux.sh` to have mimic old behavior with the new settings (added `fake-account` flag and `data-dir` flag)

## Caveats 
### Copied code
**I copied `accounts.py` directly from `pyethapp`**. I also copied some functions from `pyethapp`'s `app.py`. I *really* don't like this. 

The reason I copied `accounts.py` was because it includes the `Account` object and `Accounts` service, which is super useful. However, instead of copying, it would be much better to pull the `Accounts` `devp2p` service out and put it in a separate library. If we don't want to do that, then at least I should also include the `accounts.py` test files from `pyethapp`.

### Slower load time
Because we are using full account management, initial boot time takes longer.

### Node discovery private keys
I did not change the node discovery `privkey_hex` and `bootstrap_nodes`.